### PR TITLE
fix: Fix async method parameter parse issue on ES2017

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinspector",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "TypeScript type inspector",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -18,8 +18,8 @@
   "license": "MIT",
   "dependencies": {
     "@types/acorn": "4.0.3",
-    "reflect-metadata": "^0.1.13",
-    "acorn": "7.1.0"
+    "acorn": "7.1.0",
+    "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",

--- a/test/__snapshots__/class.spec.js.snap
+++ b/test/__snapshots__/class.spec.js.snap
@@ -203,6 +203,51 @@ Object {
 }
 `;
 
+exports[`Class Introspection Should inspect async method with parameters 1`] = `
+Object {
+  "ctor": Object {
+    "kind": "Constructor",
+    "name": "constructor",
+    "parameters": Array [],
+  },
+  "decorators": Array [],
+  "kind": "Class",
+  "methods": Array [
+    Object {
+      "decorators": Array [
+        Object {},
+      ],
+      "kind": "Method",
+      "name": "dummyMethod",
+      "parameters": Array [
+        Object {
+          "decorators": Array [],
+          "kind": "Parameter",
+          "name": "dummy",
+          "properties": Object {},
+          "type": String,
+          "typeClassification": "Primitive",
+        },
+        Object {
+          "decorators": Array [],
+          "kind": "Parameter",
+          "name": "other",
+          "properties": Object {},
+          "type": Object,
+          "typeClassification": "Primitive",
+        },
+      ],
+      "returnType": Promise,
+      "typeClassification": "Class",
+    },
+  ],
+  "name": "DummyClass",
+  "properties": Array [],
+  "type": DummyClass,
+  "typeClassification": "Class",
+}
+`;
+
 exports[`Class Introspection Should inspect class properly 1`] = `
 Object {
   "ctor": Object {

--- a/test/__snapshots__/get-parameter.spec.js.snap
+++ b/test/__snapshots__/get-parameter.spec.js.snap
@@ -45,7 +45,11 @@ exports[`Durability Should not error when provided method first than constructor
 
 exports[`Durability Should not error when provided method without parameter 1`] = `Array []`;
 
-exports[`Durability Should not error when provided proxy 1`] = `Array []`;
+exports[`Durability getConstructorParameters should not error when provided proxy 1`] = `Array []`;
+
+exports[`Durability getMethodParameters should not error when provided proxy 1`] = `Array []`;
+
+exports[`Durability getParameterNames should not error when provided proxy 1`] = `Array []`;
 
 exports[`Function Parameters Should get function parameter name 1`] = `
 Array [

--- a/test/class.spec.ts
+++ b/test/class.spec.ts
@@ -43,6 +43,15 @@ describe("Class Introspection", () => {
         expect(meta).toMatchSnapshot()
     })
 
+    it("Should inspect async method with parameters", () => {
+        class DummyClass {
+            @decorateMethod({})
+            async dummyMethod(dummy: string, other: any): Promise<number> { return 1 }
+        }
+        const meta = reflect(DummyClass)
+        expect(meta).toMatchSnapshot()
+    })
+
     it("Should inspect destructed parameters type with method decorator", () => {
         class Domain {
             constructor(

--- a/test/get-parameter.spec.ts
+++ b/test/get-parameter.spec.ts
@@ -1,4 +1,4 @@
-import { decorate, getConstructorParameters, getParameterNames } from "../src"
+import { decorate, getConstructorParameters, getParameterNames, getMethodParameters } from "../src"
 
 function globalFunction(a: any, b: any) {
 
@@ -88,7 +88,7 @@ describe("Method Parameters", () => {
                 globalFunction(par1, par2)
             }
         }
-        const result = getParameterNames(DummyClass.prototype["myMethod"])
+        const result = getMethodParameters(DummyClass, "myMethod")
         expect(result).toMatchSnapshot()
     })
 
@@ -106,7 +106,7 @@ describe("Method Parameters", () => {
                 globalFunction(par1, par2)
             }
         }
-        const result = getParameterNames(DummyClass.prototype["myMethod"])
+        const result = getMethodParameters(DummyClass, "myMethod")
         expect(result).toMatchSnapshot()
     })
 
@@ -121,7 +121,7 @@ describe("Method Parameters", () => {
                 globalFunction(par1, par2)
             }
         }
-        const result = getParameterNames(DummyClass.prototype["myMethod"])
+        const result = getMethodParameters(DummyClass, "myMethod")
         expect(result).toMatchSnapshot()
     })
 })
@@ -171,12 +171,35 @@ describe("Function Parameters", () => {
 })
 
 describe("Durability", () => {
-    it("Should not error when provided proxy", () => {
+    it("getParameterNames should not error when provided proxy", () => {
         function MyFunction() { }
         MyFunction.toString = () => {
             return "[Function]"
         }
         const result = getParameterNames(MyFunction)
+        expect(result).toMatchSnapshot()
+    })
+
+    it("getConstructorParameters should not error when provided proxy", () => {
+        class MyFunction { 
+            constructor(){}
+        }
+        MyFunction.toString = () => {
+            return "[Function]"
+        }
+        const result = getConstructorParameters(MyFunction)
+        expect(result).toMatchSnapshot()
+    })
+
+    it("getMethodParameters should not error when provided proxy", () => {
+        class MyFunction { 
+            constructor(){}
+            myMethod(){}
+        }
+        MyFunction.toString = () => {
+            return "[Function]"
+        }
+        const result = getMethodParameters(MyFunction, "myMethod")
         expect(result).toMatchSnapshot()
     })
 
@@ -190,7 +213,7 @@ describe("Durability", () => {
         class MyClass {
             myMethod() { }
         }
-        const result = getParameterNames(MyClass.prototype["myMethod"])
+        const result = getMethodParameters(MyClass, "myMethod")
         expect(result).toMatchSnapshot()
     })
 
@@ -275,7 +298,7 @@ describe("Parameter Destructuring", () => {
         class MyClass {
             myMethod({ date: tanggal, num }: MyModel) { }
         }
-        const result = getParameterNames(MyClass.prototype["myMethod"])
+        const result = getMethodParameters(MyClass, "myMethod")
         expect(result).toMatchSnapshot()
     })
 })

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
+        "target": "es6",
         "outDir": "lib",
         "declaration": true,
         "inlineSourceMap": false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2017",
     "module": "commonjs",
     "strict": true,
     "inlineSourceMap": true,


### PR DESCRIPTION
This PR fixes issue: Parsing async method parameters when targeting ES2017.
