### PR TITLE
fix: Fix array type issue when defined without type override

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,8 @@ function getReflectionType(decorators: any[], type: any) {
         return override.type
     else if (array)
         return [array.type]
+    else if (type === Array)
+        return [Object]
     else
         return type
 }

--- a/test/__snapshots__/class.spec.js.snap
+++ b/test/__snapshots__/class.spec.js.snap
@@ -156,6 +156,45 @@ Object {
 }
 `;
 
+exports[`Class Introspection Should inspect array on method parameter but without type override 1`] = `
+Object {
+  "ctor": Object {
+    "kind": "Constructor",
+    "name": "constructor",
+    "parameters": Array [],
+  },
+  "decorators": Array [],
+  "kind": "Class",
+  "methods": Array [
+    Object {
+      "decorators": Array [
+        Object {},
+      ],
+      "kind": "Method",
+      "name": "dummyMethod",
+      "parameters": Array [
+        Object {
+          "decorators": Array [],
+          "kind": "Parameter",
+          "name": "empty",
+          "properties": Object {},
+          "type": Array [
+            Object,
+          ],
+          "typeClassification": "Array",
+        },
+      ],
+      "returnType": undefined,
+      "typeClassification": undefined,
+    },
+  ],
+  "name": "DummyClass",
+  "properties": Array [],
+  "type": DummyClass,
+  "typeClassification": "Class",
+}
+`;
+
 exports[`Class Introspection Should inspect array on method parameter using @reflect.type 1`] = `
 Object {
   "ctor": Object {

--- a/test/class.spec.ts
+++ b/test/class.spec.ts
@@ -77,6 +77,17 @@ describe("Class Introspection", () => {
         expect(meta).toMatchSnapshot()
     })
 
+    it("Should inspect array on method parameter but without type override", () => {
+        class EmptyClass { }
+        class DummyClass {
+            @decorateMethod({})
+            dummyMethod(empty: EmptyClass[]) { }
+        }
+        const meta = reflect(DummyClass)
+        expect(meta.methods[0].parameters[0].type).toEqual([Object])
+        expect(meta).toMatchSnapshot()
+    })
+
     it("Should inspect array on method parameter", () => {
         class EmptyClass { }
         class DummyClass {


### PR DESCRIPTION
When a parameter of type array doesn't specify a type override will cause tinspector returned `Array` instead of `[Object]`

```typescript
class EmptyClass { }
class DummyClass {
    @decorateMethod({})
    dummyMethod(empty: EmptyClass[]) { }
}
```

Before this PR, above code wil returned the `empty` parameter of type `Array` instead of `[Object]`