### PR TITLE
feat: Add ability to introspect generic data type on generic class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinspector",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "TypeScript type inspector",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -24,7 +24,7 @@ namespace metadata {
         return meta && meta.kind === "Property" && (meta as ParameterPropertyReflection).isParameter
     }
 
-    export function isCallback(type: Function): type is ((x: any) => Class[] | Class | string | string[]) {
+    export function isCallback(type: any): type is ((x: any) => Class[] | Class | string | string[]) {
         return typeof type === "function" && !type.prototype
     }
 

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -1,4 +1,4 @@
-import { array, ignore, noop, parameterProperties, type } from "./decorators"
+import { ignore, noop, parameterProperties, type } from "./decorators"
 import { metadata, useCache } from "./helpers"
 import { parseFunction } from "./parser"
 import { Class, ClassReflection, ObjectReflection, Reflection } from "./types"
@@ -91,12 +91,6 @@ reflect.ignore = ignore
  * @param info Additional information about type (readonly, partial etc)
  */
 reflect.type = type
-
-/**
- * Add type information for array element
- * @param type Data type of array element
- */
-reflect.array = array
 
 /**
  * Mark all constructor parameters as properties

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export const DecoratorOptionId = Symbol("tinspector:decoratorOption")
 export const DecoratorId = Symbol("tinspector:decoratorId")
 
 export type Class<T = any> = new (...arg: any[]) => T
+export type TypeOverride = string | string[] | Class | Class[]
 export type DecoratorIterator = (type: DecoratorTargetType, target: string, index?: number) => any[]
 export type DecoratorTargetType = "Method" | "Class" | "Parameter" | "Property"
 export interface NativeDecorator {
@@ -19,6 +20,9 @@ export interface NativeDecorator {
 export interface NativeParameterDecorator extends NativeDecorator {
     targetType: "Parameter",
     targetIndex: number
+}
+export interface TypeOverrideOption {
+    genericType: TypeOverride[]
 }
 
 export type Reflection = ParameterReflection | FunctionReflection | PropertyReflection | MethodReflection | ClassReflection | ObjectReflection | ConstructorReflection
@@ -77,20 +81,14 @@ export interface ObjectReflection extends ReflectionBase {
     kind: "Object",
     members: Reflection[]
 }
-export interface ArrayDecorator {
-    kind: "Array",
-    type: Class | string,
-    target: Class
-}
 export interface NoopDecorator {
     kind: "Noop",
-    type?: () => string | string[] | Class | Class[],
     target: Class
 }
 export interface TypeDecorator {
     kind: "Override",
-    type: Class[] | Class | string | string[] | ((x:any) => Class[] | Class | string | string[]),
-    info?: string,
+    type: TypeOverride | ((x: any) => TypeOverride),
+    genericParams: (string | string[])[]
     target: Class
 }
 export interface PrivateDecorator {
@@ -101,7 +99,7 @@ export interface ParameterPropertiesDecorator {
 }
 export interface GenericTypeDecorator {
     kind: "GenericType",
-    types: (Class[] | Class | string | string[])[]
+    types: (TypeOverride)[]
     target: Class
 }
 export interface GenericTemplateDecorator {

--- a/test/__snapshots__/class.spec.js.snap
+++ b/test/__snapshots__/class.spec.js.snap
@@ -13,7 +13,7 @@ Object {
     Object {
       "decorators": Array [
         Object {
-          "info": undefined,
+          "genericParams": Array [],
           "kind": "Override",
           "target": DummyClass,
           "type": Array [
@@ -43,55 +43,6 @@ Object {
 }
 `;
 
-exports[`Class Introspection Should able to override type with other type 1`] = `
-Object {
-  "ctor": Object {
-    "kind": "Constructor",
-    "name": "constructor",
-    "parameters": Array [],
-  },
-  "decorators": Array [],
-  "kind": "Class",
-  "methods": Array [
-    Object {
-      "decorators": Array [],
-      "kind": "Method",
-      "name": "method",
-      "parameters": Array [
-        Object {
-          "decorators": Array [
-            Object {
-              "info": "Readonly",
-              "kind": "Override",
-              "target": DummyClass,
-              "type": OtherDummyClass,
-              Symbol(tinspector:decoratorId): Symbol(override),
-              Symbol(tinspector:decoratorOption): Object {
-                "allowMultiple": false,
-                "inherit": false,
-              },
-            },
-          ],
-          "fields": Object {},
-          "index": 0,
-          "kind": "Parameter",
-          "name": "dummy",
-          "type": OtherDummyClass,
-          "typeClassification": "Class",
-        },
-      ],
-      "returnType": undefined,
-      "typeClassification": undefined,
-    },
-  ],
-  "name": "DummyClass",
-  "properties": Array [],
-  "super": Object,
-  "type": DummyClass,
-  "typeClassification": "Class",
-}
-`;
-
 exports[`Class Introspection Should inspect array on constructor parameters 1`] = `
 Object {
   "ctor": Object {
@@ -101,10 +52,13 @@ Object {
       Object {
         "decorators": Array [
           Object {
-            "kind": "Array",
+            "genericParams": Array [],
+            "kind": "Override",
             "target": DummyClass,
-            "type": EmptyClass,
-            Symbol(tinspector:decoratorId): Symbol(array),
+            "type": Array [
+              EmptyClass,
+            ],
+            Symbol(tinspector:decoratorId): Symbol(override),
             Symbol(tinspector:decoratorOption): Object {
               "allowMultiple": false,
               "inherit": false,
@@ -165,10 +119,13 @@ Object {
         Object {
           "decorators": Array [
             Object {
-              "kind": "Array",
+              "genericParams": Array [],
+              "kind": "Override",
               "target": DummyClass,
-              "type": EmptyClass,
-              Symbol(tinspector:decoratorId): Symbol(array),
+              "type": Array [
+                EmptyClass,
+              ],
+              Symbol(tinspector:decoratorId): Symbol(override),
               Symbol(tinspector:decoratorOption): Object {
                 "allowMultiple": false,
                 "inherit": false,
@@ -268,7 +225,7 @@ Object {
         Object {
           "decorators": Array [
             Object {
-              "info": undefined,
+              "genericParams": Array [],
               "kind": "Override",
               "target": DummyClass,
               "type": Array [
@@ -535,7 +492,7 @@ Object {
         Object {
           "decorators": Array [
             Object {
-              "info": undefined,
+              "genericParams": Array [],
               "kind": "Override",
               "target": DummyClass,
               "type": Domain,
@@ -606,7 +563,7 @@ Object {
         Object {
           "decorators": Array [
             Object {
-              "info": undefined,
+              "genericParams": Array [],
               "kind": "Override",
               "target": DummyClass,
               "type": Domain,
@@ -741,7 +698,6 @@ Object {
         Object {
           "kind": "Noop",
           "target": DummyClass,
-          "type": undefined,
           Symbol(tinspector:decoratorId): Symbol(noop),
           Symbol(tinspector:decoratorOption): Object {
             "allowMultiple": false,
@@ -902,7 +858,6 @@ Object {
         Object {
           "kind": "Noop",
           "target": DummyClass,
-          "type": undefined,
           Symbol(tinspector:decoratorId): Symbol(noop),
           Symbol(tinspector:decoratorOption): Object {
             "allowMultiple": false,
@@ -922,7 +877,6 @@ Object {
         Object {
           "kind": "Noop",
           "target": DummyClass,
-          "type": undefined,
           Symbol(tinspector:decoratorId): Symbol(noop),
           Symbol(tinspector:decoratorOption): Object {
             "allowMultiple": false,

--- a/test/__snapshots__/decorator.spec.js.snap
+++ b/test/__snapshots__/decorator.spec.js.snap
@@ -1356,247 +1356,6 @@ Object {
 }
 `;
 
-exports[`Decorator Type Override noop Should able to mark generic type with @noop() 1`] = `
-Object {
-  "ctor": Object {
-    "kind": "Constructor",
-    "name": "constructor",
-    "parameters": Array [],
-  },
-  "decorators": Array [
-    Object {
-      "kind": "GenericType",
-      "target": MyClass,
-      "types": Array [
-        Number,
-      ],
-      Symbol(tinspector:decoratorId): Symbol(genericType),
-      Symbol(tinspector:decoratorOption): Object {
-        "allowMultiple": false,
-        "inherit": false,
-      },
-    },
-  ],
-  "kind": "Class",
-  "methods": Array [],
-  "name": "MyClass",
-  "properties": Array [
-    Object {
-      "decorators": Array [],
-      "get": undefined,
-      "kind": "Property",
-      "name": "data",
-      "set": undefined,
-      "type": Number,
-      "typeClassification": "Primitive",
-    },
-  ],
-  "super": MyOtherClass,
-  "type": MyClass,
-  "typeClassification": "Class",
-}
-`;
-
-exports[`Decorator Type Override noop Should able to override array type with @noop() 1`] = `
-Object {
-  "ctor": Object {
-    "kind": "Constructor",
-    "name": "constructor",
-    "parameters": Array [],
-  },
-  "decorators": Array [],
-  "kind": "Class",
-  "methods": Array [],
-  "name": "MyClass",
-  "properties": Array [
-    Object {
-      "decorators": Array [
-        Object {
-          "kind": "Noop",
-          "target": MyClass,
-          "type": ,
-          Symbol(tinspector:decoratorId): Symbol(noop),
-          Symbol(tinspector:decoratorOption): Object {
-            "allowMultiple": false,
-            "inherit": false,
-          },
-        },
-      ],
-      "get": undefined,
-      "kind": "Property",
-      "name": "arr",
-      "set": undefined,
-      "type": Array [
-        Number,
-      ],
-      "typeClassification": "Array",
-    },
-  ],
-  "super": Object,
-  "type": MyClass,
-  "typeClassification": "Class",
-}
-`;
-
-exports[`Decorator Type Override noop Should able to override method return type with @noop() 1`] = `
-Object {
-  "ctor": Object {
-    "kind": "Constructor",
-    "name": "constructor",
-    "parameters": Array [],
-  },
-  "decorators": Array [],
-  "kind": "Class",
-  "methods": Array [
-    Object {
-      "decorators": Array [
-        Object {
-          "kind": "Noop",
-          "target": MyClass,
-          "type": ,
-          Symbol(tinspector:decoratorId): Symbol(noop),
-          Symbol(tinspector:decoratorOption): Object {
-            "allowMultiple": false,
-            "inherit": false,
-          },
-        },
-      ],
-      "kind": "Method",
-      "name": "myMethod",
-      "parameters": Array [],
-      "returnType": Number,
-      "typeClassification": "Primitive",
-    },
-  ],
-  "name": "MyClass",
-  "properties": Array [],
-  "super": Object,
-  "type": MyClass,
-  "typeClassification": "Class",
-}
-`;
-
-exports[`Decorator Type Override noop Should not cause cross reference error on circular dependency 1`] = `
-Object {
-  "ctor": Object {
-    "kind": "Constructor",
-    "name": "constructor",
-    "parameters": Array [],
-  },
-  "decorators": Array [],
-  "kind": "Class",
-  "methods": Array [],
-  "name": "MyClass",
-  "properties": Array [
-    Object {
-      "decorators": Array [
-        Object {
-          "kind": "Noop",
-          "target": MyClass,
-          "type": ,
-          Symbol(tinspector:decoratorId): Symbol(noop),
-          Symbol(tinspector:decoratorOption): Object {
-            "allowMultiple": false,
-            "inherit": false,
-          },
-        },
-      ],
-      "get": undefined,
-      "kind": "Property",
-      "name": "other",
-      "set": undefined,
-      "type": Array [
-        OtherClass,
-      ],
-      "typeClassification": "Array",
-    },
-  ],
-  "super": Object,
-  "type": MyClass,
-  "typeClassification": "Class",
-}
-`;
-
-exports[`Decorator Type Override noop Should not cause cross reference error on circular dependency 2`] = `
-Object {
-  "ctor": Object {
-    "kind": "Constructor",
-    "name": "constructor",
-    "parameters": Array [],
-  },
-  "decorators": Array [],
-  "kind": "Class",
-  "methods": Array [],
-  "name": "OtherClass",
-  "properties": Array [
-    Object {
-      "decorators": Array [
-        Object {
-          "kind": "Noop",
-          "target": OtherClass,
-          "type": ,
-          Symbol(tinspector:decoratorId): Symbol(noop),
-          Symbol(tinspector:decoratorOption): Object {
-            "allowMultiple": false,
-            "inherit": false,
-          },
-        },
-      ],
-      "get": undefined,
-      "kind": "Property",
-      "name": "my",
-      "set": undefined,
-      "type": Array [
-        MyClass,
-      ],
-      "typeClassification": "Array",
-    },
-  ],
-  "super": Object,
-  "type": OtherClass,
-  "typeClassification": "Class",
-}
-`;
-
-exports[`Decorator Type Override noop Should not cause issue when decorated with @noop() 1`] = `
-Object {
-  "ctor": Object {
-    "kind": "Constructor",
-    "name": "constructor",
-    "parameters": Array [],
-  },
-  "decorators": Array [],
-  "kind": "Class",
-  "methods": Array [],
-  "name": "MyClass",
-  "properties": Array [
-    Object {
-      "decorators": Array [
-        Object {
-          "kind": "Noop",
-          "target": MyClass,
-          "type": undefined,
-          Symbol(tinspector:decoratorId): Symbol(noop),
-          Symbol(tinspector:decoratorOption): Object {
-            "allowMultiple": false,
-            "inherit": false,
-          },
-        },
-      ],
-      "get": undefined,
-      "kind": "Property",
-      "name": "data",
-      "set": undefined,
-      "type": Number,
-      "typeClassification": "Primitive",
-    },
-  ],
-  "super": Object,
-  "type": MyClass,
-  "typeClassification": "Class",
-}
-`;
-
 exports[`Decorator Type Override type Should able to mark generic type with @type() 1`] = `
 Object {
   "ctor": Object {
@@ -1653,7 +1412,7 @@ Object {
     Object {
       "decorators": Array [
         Object {
-          "info": undefined,
+          "genericParams": Array [],
           "kind": "Override",
           "target": MyClass,
           "type": ,
@@ -1693,7 +1452,7 @@ Object {
     Object {
       "decorators": Array [
         Object {
-          "info": undefined,
+          "genericParams": Array [],
           "kind": "Override",
           "target": MyClass,
           "type": Array,
@@ -1732,7 +1491,7 @@ Object {
     Object {
       "decorators": Array [
         Object {
-          "info": undefined,
+          "genericParams": Array [],
           "kind": "Override",
           "target": MyClass,
           "type": Boolean,
@@ -1771,7 +1530,7 @@ Object {
     Object {
       "decorators": Array [
         Object {
-          "info": undefined,
+          "genericParams": Array [],
           "kind": "Override",
           "target": MyClass,
           "type": Date,
@@ -1810,7 +1569,7 @@ Object {
     Object {
       "decorators": Array [
         Object {
-          "info": undefined,
+          "genericParams": Array [],
           "kind": "Override",
           "target": MyClass,
           "type": Number,
@@ -1849,7 +1608,7 @@ Object {
     Object {
       "decorators": Array [
         Object {
-          "info": undefined,
+          "genericParams": Array [],
           "kind": "Override",
           "target": MyClass,
           "type": Object,
@@ -1888,7 +1647,7 @@ Object {
     Object {
       "decorators": Array [
         Object {
-          "info": undefined,
+          "genericParams": Array [],
           "kind": "Override",
           "target": MyClass,
           "type": Promise,
@@ -1927,7 +1686,7 @@ Object {
     Object {
       "decorators": Array [
         Object {
-          "info": undefined,
+          "genericParams": Array [],
           "kind": "Override",
           "target": MyClass,
           "type": String,
@@ -1966,7 +1725,7 @@ Object {
     Object {
       "decorators": Array [
         Object {
-          "info": undefined,
+          "genericParams": Array [],
           "kind": "Override",
           "target": MyClass,
           "type": ,
@@ -2007,7 +1766,7 @@ Object {
     Object {
       "decorators": Array [
         Object {
-          "info": undefined,
+          "genericParams": Array [],
           "kind": "Override",
           "target": MyClass,
           "type": ,
@@ -2049,7 +1808,7 @@ Object {
     Object {
       "decorators": Array [
         Object {
-          "info": undefined,
+          "genericParams": Array [],
           "kind": "Override",
           "target": OtherClass,
           "type": ,

--- a/test/__snapshots__/generic.spec.js.snap
+++ b/test/__snapshots__/generic.spec.js.snap
@@ -910,7 +910,7 @@ Object {
       Object {
         "decorators": Array [
           Object {
-            "info": undefined,
+            "genericParams": Array [],
             "kind": "Override",
             "target": SuperClass,
             "type": "T",
@@ -950,6 +950,170 @@ Object {
   "properties": Array [],
   "super": Object,
   "type": SuperClass,
+  "typeClassification": "Class",
+}
+`;
+
+exports[`Generic Type as Template Type Should able to inspect array generic on getter 1`] = `
+Object {
+  "ctor": Object {
+    "kind": "Constructor",
+    "name": "constructor",
+    "parameters": Array [],
+  },
+  "decorators": Array [
+    Object {
+      "kind": "GenericType",
+      "target": DynamicType,
+      "types": Array [
+        String,
+      ],
+      Symbol(tinspector:decoratorId): Symbol(genericType),
+      Symbol(tinspector:decoratorOption): Object {
+        "allowMultiple": false,
+        "inherit": false,
+      },
+    },
+  ],
+  "kind": "Class",
+  "methods": Array [],
+  "name": "DynamicType",
+  "properties": Array [
+    Object {
+      "decorators": Array [],
+      "get": undefined,
+      "kind": "Property",
+      "name": "prop",
+      "set": undefined,
+      "type": String,
+      "typeClassification": "Primitive",
+    },
+  ],
+  "super": CustomGeneric,
+  "type": DynamicType,
+  "typeClassification": "Class",
+}
+`;
+
+exports[`Generic Type as Template Type Should able to inspect array generic on method parameter 1`] = `
+Object {
+  "ctor": Object {
+    "kind": "Constructor",
+    "name": "constructor",
+    "parameters": Array [],
+  },
+  "decorators": Array [
+    Object {
+      "kind": "GenericType",
+      "target": DynamicType,
+      "types": Array [
+        String,
+      ],
+      Symbol(tinspector:decoratorId): Symbol(genericType),
+      Symbol(tinspector:decoratorOption): Object {
+        "allowMultiple": false,
+        "inherit": false,
+      },
+    },
+  ],
+  "kind": "Class",
+  "methods": Array [],
+  "name": "DynamicType",
+  "properties": Array [
+    Object {
+      "decorators": Array [],
+      "get": undefined,
+      "kind": "Property",
+      "name": "prop",
+      "set": undefined,
+      "type": String,
+      "typeClassification": "Primitive",
+    },
+  ],
+  "super": CustomGeneric,
+  "type": DynamicType,
+  "typeClassification": "Class",
+}
+`;
+
+exports[`Generic Type as Template Type Should able to inspect array generic on property 1`] = `
+Object {
+  "ctor": Object {
+    "kind": "Constructor",
+    "name": "constructor",
+    "parameters": Array [],
+  },
+  "decorators": Array [
+    Object {
+      "kind": "GenericType",
+      "target": DynamicType,
+      "types": Array [
+        String,
+      ],
+      Symbol(tinspector:decoratorId): Symbol(genericType),
+      Symbol(tinspector:decoratorOption): Object {
+        "allowMultiple": false,
+        "inherit": false,
+      },
+    },
+  ],
+  "kind": "Class",
+  "methods": Array [],
+  "name": "DynamicType",
+  "properties": Array [
+    Object {
+      "decorators": Array [],
+      "get": undefined,
+      "kind": "Property",
+      "name": "prop",
+      "set": undefined,
+      "type": String,
+      "typeClassification": "Primitive",
+    },
+  ],
+  "super": CustomGeneric,
+  "type": DynamicType,
+  "typeClassification": "Class",
+}
+`;
+
+exports[`Generic Type as Template Type Should able to inspect array generic type on method 1`] = `
+Object {
+  "ctor": Object {
+    "kind": "Constructor",
+    "name": "constructor",
+    "parameters": Array [],
+  },
+  "decorators": Array [
+    Object {
+      "kind": "GenericType",
+      "target": DynamicType,
+      "types": Array [
+        String,
+      ],
+      Symbol(tinspector:decoratorId): Symbol(genericType),
+      Symbol(tinspector:decoratorOption): Object {
+        "allowMultiple": false,
+        "inherit": false,
+      },
+    },
+  ],
+  "kind": "Class",
+  "methods": Array [],
+  "name": "DynamicType",
+  "properties": Array [
+    Object {
+      "decorators": Array [],
+      "get": undefined,
+      "kind": "Property",
+      "name": "prop",
+      "set": undefined,
+      "type": String,
+      "typeClassification": "Primitive",
+    },
+  ],
+  "super": CustomGeneric,
+  "type": DynamicType,
   "typeClassification": "Class",
 }
 `;

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -8,7 +8,6 @@ Object {
   "DESIGN_TYPE": "design:type",
   "DecoratorId": Symbol(tinspector:decoratorId),
   "DecoratorOptionId": Symbol(tinspector:decoratorOption),
-  "array": array,
   "decorate": decorate,
   "decorateClass": decorateClass,
   "decorateMethod": decorateMethod,

--- a/test/__snapshots__/inheritance.spec.js.snap
+++ b/test/__snapshots__/inheritance.spec.js.snap
@@ -1047,7 +1047,6 @@ Object {
         Object {
           "kind": "Noop",
           "target": MyClass,
-          "type": undefined,
           Symbol(tinspector:decoratorId): Symbol(noop),
           Symbol(tinspector:decoratorOption): Object {
             "allowMultiple": false,
@@ -1593,7 +1592,6 @@ Object {
         Object {
           "kind": "Noop",
           "target": ChildClass,
-          "type": undefined,
           Symbol(tinspector:decoratorId): Symbol(noop),
           Symbol(tinspector:decoratorOption): Object {
             "allowMultiple": false,

--- a/test/class.spec.ts
+++ b/test/class.spec.ts
@@ -21,7 +21,7 @@ describe("Class Introspection", () => {
         class EmptyClass { }
         @decorateClass({})
         class DummyClass {
-            constructor(@reflect.array(EmptyClass) empty: EmptyClass[]) { }
+            constructor(@reflect.type([EmptyClass]) empty: EmptyClass[]) { }
         }
         const meta = reflect(DummyClass)
         expect(meta).toMatchSnapshot()
@@ -104,7 +104,7 @@ describe("Class Introspection", () => {
         class EmptyClass { }
         class DummyClass {
             @decorateMethod({})
-            dummyMethod(@reflect.array(EmptyClass) empty: EmptyClass[]) { }
+            dummyMethod(@reflect.type([EmptyClass]) empty: EmptyClass[]) { }
         }
         const meta = reflect(DummyClass)
         expect(meta.methods[0].parameters[0].type).toEqual([EmptyClass])
@@ -163,17 +163,6 @@ describe("Class Introspection", () => {
             dummyMethod(@reflect.type(Domain) { a, b, child: { c, d, child: { e, f } } }: Domain) { }
         }
         const meta = reflect(DummyClass)
-        expect(meta).toMatchSnapshot()
-    })
-
-    it("Should able to override type with other type", () => {
-        class OtherDummyClass { }
-        class DummyClass {
-            method(@reflect.type(OtherDummyClass, "Readonly") dummy: Readonly<OtherDummyClass>) { }
-        }
-        const meta = reflect(DummyClass)
-        expect(meta.methods[0].parameters[0].decorators[0].type).toEqual(OtherDummyClass)
-        expect(meta.methods[0].parameters[0].decorators[0].info).toEqual("Readonly")
         expect(meta).toMatchSnapshot()
     })
 

--- a/test/decorator.spec.ts
+++ b/test/decorator.spec.ts
@@ -442,57 +442,7 @@ describe("Decorator", () => {
     })
 
     describe("Type Override", () => {
-        describe("noop", () => {
-            it("Should able to override method return type with @noop()", () => {
-                class MyClass {
-                    @noop(x => Number)
-                    myMethod() { }
-                }
-                expect(reflect(MyClass)).toMatchSnapshot()
-            })
-
-            it("Should able to override array type with @noop()", () => {
-                class MyClass {
-                    @noop(x => [Number])
-                    arr: Number[] = [1]
-                }
-                expect(reflect(MyClass)).toMatchSnapshot()
-            })
-
-            it("Should not cause cross reference error on circular dependency", () => {
-                class OtherClass {
-                    @noop(x => [MyClass])
-                    my: MyClass[] = []
-                }
-                class MyClass {
-                    @noop(x => [OtherClass])
-                    other: OtherClass[] = []
-                }
-                expect(reflect(MyClass)).toMatchSnapshot()
-                expect(reflect(OtherClass)).toMatchSnapshot()
-            })
-
-            it("Should not cause issue when decorated with @noop()", () => {
-                class MyClass {
-                    @noop()
-                    data: number = 123
-                }
-                expect(reflect(MyClass)).toMatchSnapshot()
-            })
-
-            it("Should able to mark generic type with @noop()", () => {
-
-                @generic.template("T")
-                class MyOtherClass<T> {
-                    @noop(x => "T")
-                    data: T = {} as any
-                }
-
-                @generic.type(Number)
-                class MyClass extends MyOtherClass<Number> { }
-                expect(reflect(MyClass)).toMatchSnapshot()
-            })
-        })
+        
         describe("type", () => {
             it("Should able to override method return type with @type() of type Number", () => {
                 class MyClass {

--- a/test/generic.spec.ts
+++ b/test/generic.spec.ts
@@ -199,6 +199,61 @@ describe("Array Type", () => {
     })
 })
 
+describe("Generic Type as Template Type", () => {
+    @generic.template("T")
+    class CustomGeneric<T> {
+        @type("T")
+        prop: T = {} as any
+    }
+    it("Should able to inspect array generic type on method", () => {
+        @generic.template("T")
+        class SuperClass<T> {
+            @type(CustomGeneric, "T")
+            method(): CustomGeneric<T> { return {} as any }
+        }
+        @generic.type(String)
+        class MyClass extends SuperClass<string>{ }
+        const meta = reflect(MyClass)
+        const par = reflect(meta.methods[0].returnType)
+        expect(par).toMatchSnapshot()
+    })
+    it("Should able to inspect array generic on method parameter", () => {
+        @generic.template("T")
+        class SuperClass<T> {
+            method(@type(CustomGeneric, "T") par: CustomGeneric<T>) { return {} as any }
+        }
+        @generic.type(String)
+        class MyClass extends SuperClass<string>{ }
+        const meta = reflect(MyClass)
+        const par = reflect(meta.methods[0].parameters[0].type)
+        expect(par).toMatchSnapshot()
+    })
+    it("Should able to inspect array generic on property", () => {
+        @generic.template("T")
+        class SuperClass<T> {
+            @type(CustomGeneric, "T")
+            prop: CustomGeneric<T> = {} as any
+        }
+        @generic.type(String)
+        class MyClass extends SuperClass<string>{ }
+        const meta = reflect(MyClass)
+        const par = reflect(meta.properties[0].type)
+        expect(par).toMatchSnapshot()
+    })
+    it("Should able to inspect array generic on getter", () => {
+        @generic.template("T")
+        class SuperClass<T> {
+            @type(CustomGeneric, "T")
+            get prop(): CustomGeneric<T> { return {} as any }
+        }
+        @generic.type(String)
+        class MyClass extends SuperClass<string>{ }
+        const meta = reflect(MyClass)
+        const par = reflect(meta.properties[0].type)
+        expect(par).toMatchSnapshot()
+    })
+})
+
 describe("Error Handling", () => {
     it("Should show proper error when no @generic.types() provided", () => {
         @generic.template("T")


### PR DESCRIPTION
This PR possible to introspect: 

```typescript
class CustomGeneric<T> {
    prop: T = {} as any
}
class SuperClass<T> {
    method(): CustomGeneric<T> { return {} as any }
}
class MyClass extends SuperClass<string>{ }
```

Previously its not possible to introspect return type of `SuperClass.method()` method